### PR TITLE
Export EasyEDA HOLEs as non-plated KiCad holes

### DIFF
--- a/src/kicad_converter.js
+++ b/src/kicad_converter.js
@@ -35,7 +35,7 @@ const KI_FOOTPRINT_TEMPLATES = {
   line:
     "\t(fp_line (start {startX} {startY}) (end {endX} {endY}) (layer {layers}) (width {strokeWidth}))\n",
   hole:
-    "\t(pad \"\" thru_hole circle (at {posX} {posY}) (size {size} {size}) (drill {size}) (layers *.Cu *.Mask))\n",
+    "\t(pad \"\" np_thru_hole circle (at {posX} {posY}) (size {size} {size}) (drill {size}) (layers *.Mask))\n",
   via:
     "\t(pad \"\" thru_hole circle (at {posX} {posY}) (size {diameter} {diameter}) (drill {size}) (layers *.Cu *.Paste *.Mask))\n",
   circle:


### PR DESCRIPTION
## Summary

This PR continues the fix for issue `#1` by correcting how EasyEDA `HOLE` shapes are exported to KiCad footprints.

The previous PR fixed the malformed output caused by only replacing the first `{size}` placeholder. This follow-up fixes the remaining hole semantics so standalone `HOLE` entries are exported as non-plated holes instead of plated through-hole pads.

## Changes

- export EasyEDA `HOLE` shapes as `np_thru_hole`
- change exported hole layers from `*.Cu *.Mask` to `*.Mask`
- keep the existing hole size calculation based on the source `HOLE` radius

## Testing

- verified against the sample part from issue `#1`: `C5342202`
- confirmed generated hole output is now valid KiCad syntax
- confirmed generated holes now export as non-plated holes

## Notes

EasyEDA `HOLE` records only provide a single radius value, so this PR does not attempt to infer separate pad size and drill size from the datasheet. It fixes the KiCad export semantics without inventing geometry not present in the source data.

Closes the remaining exporter behavior described in `#1`.