### PR TITLE
Add datasheet download option to extension popup

### DIFF
--- a/src/popup.css
+++ b/src/popup.css
@@ -165,6 +165,10 @@ h1 {
   color: #1c1f24;
 }
 
+.option.disabled {
+  color: #94a3b8;
+}
+
 /* Checkbox alignment tweaks. */
 .option input {
   margin: 0;
@@ -181,6 +185,10 @@ h1 {
 /* Error state for status messages. */
 .status.error {
   color: #b42318;
+}
+
+.status.warning {
+  color: #9a6700;
 }
 
 .footer {

--- a/src/popup.html
+++ b/src/popup.html
@@ -53,6 +53,10 @@
           <input type="checkbox" id="downloadModel" checked />
           3D Model
         </label>
+        <label class="option" id="downloadDatasheetOption">
+          <input type="checkbox" id="downloadDatasheet" />
+          <span id="downloadDatasheetLabel">Datasheet</span>
+        </label>
       </div>
       <!-- Settings section for download organization. -->
       <section class="settings" aria-label="Settings">

--- a/src/popup.js
+++ b/src/popup.js
@@ -22,6 +22,9 @@ const statusEl = document.getElementById("status");
 const downloadSymbolEl = document.getElementById("downloadSymbol");
 const downloadFootprintEl = document.getElementById("downloadFootprint");
 const downloadModelEl = document.getElementById("downloadModel");
+const downloadDatasheetEl = document.getElementById("downloadDatasheet");
+const downloadDatasheetOptionEl = document.getElementById("downloadDatasheetOption");
+const downloadDatasheetLabelEl = document.getElementById("downloadDatasheetLabel");
 const downloadIndividuallyEl = document.getElementById("downloadIndividually");
 const symbolPreviewEl = document.getElementById("symbolPreview");
 const footprintPreviewEl = document.getElementById("footprintPreview");
@@ -37,9 +40,10 @@ const DEFAULT_SETTINGS = {
 let currentLcscId = null;
 
 // Show a status message and optionally mark it as an error.
-function setStatus(message, isError = false) {
+function setStatus(message, tone = "default") {
   statusEl.textContent = message;
-  statusEl.classList.toggle("error", isError);
+  statusEl.classList.toggle("error", tone === "error");
+  statusEl.classList.toggle("warning", tone === "warning");
 }
 
 // Determine if the user selected any download option.
@@ -47,7 +51,8 @@ function hasSelection() {
   return (
     downloadSymbolEl.checked ||
     downloadFootprintEl.checked ||
-    downloadModelEl.checked
+    downloadModelEl.checked ||
+    downloadDatasheetEl.checked
   );
 }
 
@@ -90,12 +95,14 @@ function setPreviewImage(fallbackEl, imgEl, url) {
 function requestPreviews(lcscId) {
   setPreviewLoading(symbolPreviewFallbackEl, symbolPreviewEl);
   setPreviewLoading(footprintPreviewFallbackEl, footprintPreviewEl);
+  setDatasheetAvailability(null);
   chrome.runtime.sendMessage(
     { type: "GET_PREVIEW_SVGS", lcscId },
     (response) => {
       if (chrome.runtime.lastError || !response?.ok) {
         setPreviewUnavailable(symbolPreviewFallbackEl, symbolPreviewEl);
         setPreviewUnavailable(footprintPreviewFallbackEl, footprintPreviewEl);
+        setDatasheetAvailability(null);
         return;
       }
       const symbolSvg = response.previews?.symbolSvg;
@@ -112,8 +119,25 @@ function requestPreviews(lcscId) {
         footprintPreviewEl,
         footprintUrl
       );
+      setDatasheetAvailability(response.metadata?.datasheetAvailable === true);
     }
   );
+}
+
+function setDatasheetAvailability(isAvailable) {
+  if (isAvailable === false) {
+    downloadDatasheetEl.checked = false;
+    downloadDatasheetEl.disabled = true;
+    downloadDatasheetOptionEl.classList.add("disabled");
+    downloadDatasheetLabelEl.textContent = "Datasheet (not available)";
+    updateDownloadEnabled();
+    return;
+  }
+
+  downloadDatasheetEl.disabled = false;
+  downloadDatasheetOptionEl.classList.remove("disabled");
+  downloadDatasheetLabelEl.textContent = "Datasheet";
+  updateDownloadEnabled();
 }
 
 // Apply settings values to the UI controls.
@@ -148,7 +172,7 @@ function saveSettings() {
   const settings = readSettingsFromUi();
   chrome.storage.local.set(settings, () => {
     if (chrome.runtime.lastError) {
-      setStatus("Failed to save settings.", true);
+      setStatus("Failed to save settings.", "error");
     }
   });
 }
@@ -164,7 +188,8 @@ function setPartNumber(lcscId) {
   } else {
     partNumberEl.textContent = "Not found";
     downloadButton.disabled = true;
-    setStatus("No LCSC part number found on this page.", true);
+    setStatus("No LCSC part number found on this page.", "error");
+    setDatasheetAvailability(false);
     setPreviewUnavailable(symbolPreviewFallbackEl, symbolPreviewEl, "Not found");
     setPreviewUnavailable(footprintPreviewFallbackEl, footprintPreviewEl, "Not found");
   }
@@ -176,7 +201,8 @@ function requestLcscIdFromTab(tabId) {
     if (chrome.runtime.lastError) {
       partNumberEl.textContent = "Unavailable";
       downloadButton.disabled = true;
-      setStatus("Open a JLCPCB or LCSC product page.", true);
+      setStatus("Open a JLCPCB or LCSC product page.", "error");
+      setDatasheetAvailability(false);
       setPreviewUnavailable(symbolPreviewFallbackEl, symbolPreviewEl, "Unavailable");
       setPreviewUnavailable(footprintPreviewFallbackEl, footprintPreviewEl, "Unavailable");
       return;
@@ -190,7 +216,7 @@ chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
   const tab = tabs[0];
   if (!tab?.id) {
     partNumberEl.textContent = "Unavailable";
-    setStatus("No active tab detected.", true);
+    setStatus("No active tab detected.", "error");
     return;
   }
   requestLcscIdFromTab(tab.id);
@@ -203,6 +229,7 @@ loadSettings();
 downloadSymbolEl.addEventListener("change", updateDownloadEnabled);
 downloadFootprintEl.addEventListener("change", updateDownloadEnabled);
 downloadModelEl.addEventListener("change", updateDownloadEnabled);
+downloadDatasheetEl.addEventListener("change", updateDownloadEnabled);
 downloadIndividuallyEl.addEventListener("change", saveSettings);
 
 // When clicked, validate selections and ask the background worker to export.
@@ -212,7 +239,7 @@ downloadButton.addEventListener("click", () => {
   }
 
   if (!hasSelection()) {
-    setStatus("Select at least one download option.", true);
+    setStatus("Select at least one download option.", "error");
     return;
   }
 
@@ -228,19 +255,29 @@ downloadButton.addEventListener("click", () => {
         symbol: downloadSymbolEl.checked,
         footprint: downloadFootprintEl.checked,
         model3d: downloadModelEl.checked,
+        datasheet: downloadDatasheetEl.checked,
         downloadIndividually: downloadIndividuallyEl.checked
       }
     },
     (response) => {
       updateDownloadEnabled();
       if (chrome.runtime.lastError) {
-        setStatus("Download failed. Check the console.", true);
+        setStatus("Download failed. Check the console.", "error");
         return;
       }
       if (response?.ok) {
-        setStatus("Download started.");
+        const warnings = Array.isArray(response.warnings)
+          ? response.warnings.filter(Boolean)
+          : [];
+        if (warnings.length && response.downloadCount > 0) {
+          setStatus(`Download started. ${warnings.join(" ")}`, "warning");
+        } else if (warnings.length) {
+          setStatus(warnings.join(" "), "warning");
+        } else {
+          setStatus("Download started.");
+        }
       } else {
-        setStatus(response?.error || "Download failed.", true);
+        setStatus(response?.error || "Download failed.", "error");
       }
     }
   );

--- a/src/service_worker.js
+++ b/src/service_worker.js
@@ -59,6 +59,22 @@ const canUseBlobUrl =
   typeof URL.createObjectURL === "function" &&
   typeof Blob !== "undefined";
 
+function sanitizeFilenamePart(value, fallback = "datasheet") {
+  const sanitized = String(value || "").trim().replace(/[^\w.-]+/g, "_");
+  return sanitized || fallback;
+}
+
+function normalizeUrl(value) {
+  const url = String(value || "").trim();
+  if (!url) {
+    return "";
+  }
+  if (url.startsWith("//")) {
+    return `https:${url}`;
+  }
+  return url;
+}
+
 chrome.downloads.onChanged.addListener((delta) => {
   if (!delta?.state?.current) {
     return;
@@ -145,6 +161,30 @@ async function downloadBinaryFile(filename, buffer, mimeType, conflictAction) {
     url,
     filename,
     conflictAction: conflictAction || "uniquify"
+  });
+}
+
+// Download a remote URL directly into the user's Downloads directory.
+async function downloadUrlFile(filename, url, conflictAction) {
+  return new Promise((resolve, reject) => {
+    chrome.downloads.download(
+      {
+        url,
+        filename,
+        conflictAction: conflictAction || "uniquify"
+      },
+      (downloadId) => {
+        if (chrome.runtime.lastError || !downloadId) {
+          reject(
+            new Error(
+              chrome.runtime.lastError?.message || "Download failed to start."
+            )
+          );
+          return;
+        }
+        resolve(downloadId);
+      }
+    );
   });
 }
 
@@ -428,6 +468,43 @@ function find3dModelInfo(packageDetail) {
   return null;
 }
 
+function getDatasheetInfo(cadData, lcscId) {
+  const rawUrl = [
+    cadData?.packageDetail?.dataStr?.head?.c_para?.link,
+    cadData?.dataStr?.head?.c_para?.link,
+    cadData?.lcsc?.url
+  ].find((value) => String(value || "").trim());
+  const url = normalizeUrl(rawUrl);
+  if (!url) {
+    return { url: "", filename: "" };
+  }
+
+  let extension = ".pdf";
+  try {
+    const pathname = new URL(url).pathname;
+    const lastSegment = pathname.split("/").pop() || "";
+    const match = lastSegment.match(/(\.[a-zA-Z0-9]{1,8})$/);
+    if (match) {
+      extension = match[1];
+    }
+  } catch (error) {
+    console.warn("Failed to parse datasheet URL:", error);
+  }
+
+  const baseName = sanitizeFilenamePart(
+    cadData?.packageDetail?.title ||
+      cadData?.dataStr?.head?.c_para?.package ||
+      cadData?.title ||
+      lcscId,
+    lcscId
+  );
+
+  return {
+    url,
+    filename: `${baseName}-datasheet${extension}`
+  };
+}
+
 // Main workflow: fetch, convert, and download the requested assets.
 async function exportPart(lcscId, options = {}) {
   if (!lcscId) {
@@ -442,18 +519,24 @@ async function exportPart(lcscId, options = {}) {
   const resolvedOptions = {
     symbol: options.symbol !== false,
     footprint: options.footprint !== false,
-    model3d: options.model3d !== false
+    model3d: options.model3d !== false,
+    datasheet: options.datasheet === true
   };
+
+  let downloadCount = 0;
+  const warnings = [];
 
   if (
     !resolvedOptions.symbol &&
     !resolvedOptions.footprint &&
-    !resolvedOptions.model3d
+    !resolvedOptions.model3d &&
+    !resolvedOptions.datasheet
   ) {
     throw new Error("No download options selected.");
   }
 
   const cadData = await fetchCadData(lcscId);
+  const datasheetInfo = getDatasheetInfo(cadData, lcscId);
 
   // Convert the EasyEDA CAD payload into KiCad symbol/footprint text.
   const kicadFiles = convertEasyedaCadToKicad(cadData, {
@@ -469,6 +552,7 @@ async function exportPart(lcscId, options = {}) {
         kicadFiles.symbol.content,
         "application/octet-stream"
       );
+      downloadCount += 1;
     } else {
       const symbolBlock = extractSymbolBlock(kicadFiles.symbol.content);
       const existingLibrary = await loadStoredSymbolLibrary(symbolLibraryKey);
@@ -484,6 +568,7 @@ async function exportPart(lcscId, options = {}) {
         "application/octet-stream",
         "overwrite"
       );
+      downloadCount += 1;
     }
   }
 
@@ -495,12 +580,14 @@ async function exportPart(lcscId, options = {}) {
         kicadFiles.footprint.content,
         "application/octet-stream"
       );
+      downloadCount += 1;
     } else {
       await downloadTextFile(
         `${libraryPaths.footprintDir}/${kicadFiles.footprint.name}.kicad_mod`,
         kicadFiles.footprint.content,
         "application/octet-stream"
       );
+      downloadCount += 1;
     }
   }
 
@@ -521,6 +608,7 @@ async function exportPart(lcscId, options = {}) {
           stepData,
           "application/octet-stream"
         );
+        downloadCount += 1;
       } else {
         console.warn("3D STEP download failed:", stepResponse.status);
       }
@@ -538,11 +626,33 @@ async function exportPart(lcscId, options = {}) {
           wrlData,
           "application/octet-stream"
         );
+        downloadCount += 1;
       } else {
         console.warn("3D OBJ download failed:", objResponse.status);
       }
     }
   }
+
+  if (resolvedOptions.datasheet) {
+    if (!datasheetInfo.url) {
+      warnings.push("Datasheet not available for this part.");
+    } else {
+      try {
+        await downloadUrlFile(
+          settings.downloadIndividually
+            ? datasheetInfo.filename
+            : `${DEFAULT_LIBRARY_DIR}/${datasheetInfo.filename}`,
+          datasheetInfo.url
+        );
+        downloadCount += 1;
+      } catch (error) {
+        console.warn("Datasheet download failed:", error);
+        warnings.push("Datasheet download failed.");
+      }
+    }
+  }
+
+  return { warnings, downloadCount };
 }
 
 // Listen for UI requests to export the current part.
@@ -555,6 +665,9 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
           previews: {
             symbolSvg: buildSymbolPreviewSvg(cadData),
             footprintSvg: buildFootprintPreviewSvg(cadData)
+          },
+          metadata: {
+            datasheetAvailable: Boolean(getDatasheetInfo(cadData, message.lcscId).url)
           }
         });
       })
@@ -567,7 +680,7 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
 
   if (message?.type === "EXPORT_PART") {
     exportPart(message.lcscId, message.options)
-      .then(() => sendResponse({ ok: true }))
+      .then((result) => sendResponse({ ok: true, ...result }))
       .catch((error) => {
         console.error("easy EDA downloader extension error:", error);
         sendResponse({ ok: false, error: error?.message || "Download failed." });


### PR DESCRIPTION

### Summary
This PR adds an optional datasheet download to the popup export flow.

Users can now download the part datasheet alongside the existing symbol, footprint, and 3D model exports. The popup also handles parts with no datasheet URL by disabling the option and showing that the datasheet is not available.

### Changes

- Added a Datasheet checkbox to the popup UI
- Detected datasheet availability from EasyEDA component metadata
- Downloaded the datasheet file when selected
- Disabled the datasheet option when no datasheet URL is available
- Added warning handling so datasheet failures do not fail the rest of the export

### Behavior

- If a datasheet URL exists, users can select it and it will be downloaded with the other requested assets
- If no datasheet URL exists, the checkbox is disabled and labeled Datasheet (not available)
- If the datasheet download fails to start, the other selected downloads still proceed

### Testing

- Verified JavaScript syntax for the updated files
- Confirmed the sample EasyEDA part C5342202 exposes a datasheet URL through component metadata
- Tested in Chrome

<img width="290" height="460" alt="exportDataSheetPreview" src="https://github.com/user-attachments/assets/a165b0fa-0ae1-4330-a442-4ae10597f927" />

### Notes
The datasheet download uses the URL exposed by the EasyEDA/LCSC metadata. If a part does not publish a datasheet link in that payload, the extension does not attempt to infer or scrape one.