### PR TITLE
docs/tests: add repo governance, regression suite, and footer policy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 easyEdaDownloader.crx
 easyEdaDownloader.zip
+node_modules/
+coverage/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,74 @@
+# AGENTS.md
+
+## Repository at a glance
+
+This repository is a compact browser extension that detects LCSC part numbers on supported product pages and exports EasyEDA-backed CAD assets in KiCad-friendly formats.
+
+- `src/content_script.js`: page detection and LCSC id extraction
+- `src/popup.js`: popup UI state, settings interaction, preview requests, and export requests
+- `src/service_worker.js`: orchestration, EasyEDA fetches, preview generation, storage-backed library assembly, and downloads
+- `src/kicad_converter.js`: EasyEDA-to-KiCad conversion and OBJ-to-WRL conversion
+- `tests`: regression suite for pure logic, implementation behavior, and repository hygiene
+
+`systemDesign.md` is the design source of truth.
+
+## Expected working method
+
+- Make small, explicit changes.
+- Prefer test-first or test-in-lockstep development.
+- Preserve the current runtime split instead of inventing extra layers.
+- Move code, tests, and documentation together. Do not leave design drift behind.
+- Do not refactor production files unless behavior or repository rules require it.
+
+## Comments and explainers
+
+- Add comments only when logic or data-shape handling is non-obvious.
+- Keep explainers for conversion rules, browser API boundaries, storage/download behavior, and preview-generation logic.
+- Avoid narration comments and cosmetic rewrites.
+
+## Testing expectations
+
+- Install dev dependencies with `npm install`.
+- Add or update tests with every substantive behavior change.
+- Prefer regression tests for bug fixes.
+- Use test-only harnesses, mocks, fixtures, and loaders instead of production refactors for testability.
+- Run targeted tests while iterating.
+- Run `npm test` before finalizing.
+
+## Using `systemDesign.md`
+
+- Treat `systemDesign.md` as authoritative for supported behavior and module boundaries.
+- Update it whenever implemented architecture, supported workflows, output rules, or repository constraints change.
+- If code and design disagree, fix the code or rewrite the design in the same change.
+
+## Documentation expectations
+
+- Update `README.md` when setup, testing, capabilities, or operator-visible behavior changes.
+- Keep `docs/architecture-notes.md` short and implementation-focused.
+- Use `docs/deviations.md` only for live temporary mismatches between code and design.
+- Do not turn tracked docs into backlog, review scratch space, or speculative cleanup lists.
+
+## Validation and self-review
+
+- Verify the touched behavior directly.
+- Run the relevant tests while iterating and the full suite before finalizing.
+- Do a self-review for correctness, architecture fit, documentation drift, and test coverage gaps.
+- Report assumptions, residual risks, and blocked work explicitly.
+
+## Repository hygiene
+
+- Keep generated archives, scratch artifacts, and disposable outputs out of the tracked tree.
+- Remove obsolete references when files or behaviors change.
+- Keep test harnesses and developer support code under `tests/` or other clearly developer-only locations.
+- Let the repo-hygiene tests enforce governance files, footer coverage, and documentation discipline.
+
+## Source footer
+
+- Applicable maintained source files in this repository are:
+  - JavaScript source files under `src/`
+  - JavaScript tests under `tests/`
+  - JavaScript developer support scripts added for testing or repository support, if any
+- Apply the canonical footer from `source-code-footer.txt` exactly when that file is available.
+- Adapt only the comment syntax when a non-JavaScript applicable source file ever requires the same footer.
+- Keep footer placement consistent across applicable files.
+- Do not apply the footer to Markdown docs, assets, images, fixture data, `manifest.json`, HTML/CSS unless the supplied footer policy explicitly requires it, generated files, or lockfiles.

--- a/README.md
+++ b/README.md
@@ -65,10 +65,24 @@ The popup includes a **Download individually** option.
   KiCad library structure (`easyEDADownloader.kicad_sym`, `.pretty/`, `.3dshapes/`).
 - Enabled: files are downloaded as loose files directly into Downloads.
 
+## Testing
+
+Install the dev dependencies and run the regression suite:
+
+```bash
+npm install
+npm test
+```
+
+Repository design and governance live in `systemDesign.md`, `AGENTS.md`,
+`docs/architecture-notes.md`, and `docs/deviations.md`.
+
 ## Contributing
 
 Pull requests and issues are welcome.  
 If you find a bug or want to improve support for additional components, feel free to open an issue.
+Before contributing, read `AGENTS.md` for repository working rules and
+`contributing.md` for the project’s contribution instructions.
 
 This project includes and is derived from:
 

--- a/contributing.md
+++ b/contributing.md
@@ -4,6 +4,10 @@ Thanks for your interest in contributing to **easyEdaDownloader**.
 
 This project is a Chrome extension that extracts an LCSC part number from **JLCPCB** or **LCSC** product pages and downloads related **EasyEDA** symbol data, footprint data, and 3D model files. Please keep the project’s scope and constraints in mind while contributing. :contentReference[oaicite:1]{index=1}
 
+These are the contribution instructions referenced from `README.md`. Read
+`AGENTS.md` before changing code, tests, or governance docs so your work stays
+aligned with the repository’s working rules.
+
 ## Table of contents
 
 - [Code of conduct](#code-of-conduct)
@@ -56,3 +60,39 @@ Per the project disclaimer: downloaded files may be incorrect; contributors shou
 ```bash
 git clone https://github.com/JoeShade/easyEdaDownloader.git
 cd easyEdaDownloader
+npm install
+```
+
+Use `README.md` for the user-facing overview and setup summary. Use this file
+for contribution expectations and `AGENTS.md` for repository working method,
+testing discipline, documentation rules, and source-footer policy.
+
+## Running and debugging
+
+- Load the extension as an unpacked extension from `chrome://extensions` while developing.
+- Use the extension service worker console and the target page console when debugging extraction or download issues.
+- Run the unit tests with:
+
+```bash
+npm test
+```
+
+## Change guidelines
+
+- Keep changes small and explicit.
+- Do not change runtime behavior casually.
+- Update tests and docs together when behavior or repository rules change.
+
+## Commit and PR guidelines
+
+- Run the unit tests with `npm test` before submitting a pull request.
+- Summarize the user-visible or repository-level impact of the change in the pull request.
+- Call out any manual verification, assumptions, or remaining risks.
+
+## Security
+
+Do not commit secrets, private keys, or browser/profile data. Report security-sensitive issues privately instead of opening a public issue when appropriate.
+
+## License
+
+By contributing, you agree that your contributions will be distributed under the repository license.

--- a/docs/architecture-notes.md
+++ b/docs/architecture-notes.md
@@ -1,0 +1,24 @@
+# Architecture Notes
+
+This file records short implementation notes that supplement, but do not replace, [systemDesign.md](../systemDesign.md).
+
+## Layer boundaries
+
+- `src/content_script.js`: DOM inspection and LCSC id extraction only
+- `src/popup.js`: popup UI state, settings, preview requests, and export requests
+- `src/service_worker.js`: network fetches, preview generation, symbol-library merging, and downloads
+- `src/kicad_converter.js`: EasyEDA parsing, KiCad text generation, and OBJ-to-WRL conversion
+
+## Testability notes
+
+- `src/kicad_converter.js` is the main pure logic boundary and should stay the easiest module to unit test directly.
+- `src/content_script.js` should stay small and DOM-driven so it can be exercised with markup fixtures.
+- `src/popup.js` should keep browser messaging and DOM updates visible enough to test with mocked `chrome.*` APIs.
+- `src/service_worker.js` should keep browser-dependent orchestration there, with tests using mocks instead of browser-run end-to-end flows.
+
+## Current implementation caveats worth preserving
+
+- The popup does not fetch or convert CAD data directly; it only requests that work.
+- The service worker owns preview-generation behavior, so preview regressions belong to service-worker tests.
+- Symbol library append behavior depends on `chrome.storage.local`, not on local filesystem reads.
+- The current repository is intentionally compact; do not impose extra architectural layers that are not already implemented.

--- a/docs/deviations.md
+++ b/docs/deviations.md
@@ -1,0 +1,5 @@
+# Current Deviations from `systemDesign.md`
+
+No material code/design mismatches are intentionally tracked at this time.
+
+Use this file only for active temporary divergences that should be reconciled in code or in `systemDesign.md`. Remove resolved items instead of leaving backlog or historical notes behind.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "easyeda-downloader",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "jsdom": "^29.0.1",
+    "vitest": "^4.1.0"
+  }
+}

--- a/src/kicad_converter.js
+++ b/src/kicad_converter.js
@@ -1452,12 +1452,44 @@ export function convertObjToWrlString(objData) {
   return convertObjToWrl(objData);
 }
 /*
- * This file is part of easyEdaDownloader.
- *
- * easyEdaDownloader is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This software is derived from easyeda2kicad.py by uPesy.
- */
+######################################################################################################################
+
+
+                                        AAAAAAAA
+                                      AAAA    AAAAA              AAAAAAAA
+                                    AAA          AAA           AAAA    AAA
+                                    AA            AA          AAA       AAA
+                                    AA            AAAAAAAAAA  AAA       AAAAAAAAAA
+                                    AAA                  AAA  AAA               AA
+                                     AAA                AAA    AAAAA            AA
+                                      AAAAA            AAA        AAA           AA
+                                         AAA          AAA                       AA
+                                         AAA         AAA                        AA
+                                         AA         AAA                         AA
+                                         AA        AAA                          AA
+                                        AAA       AAAAAAAAA                     AA
+                                        AAA       AAAAAAAAA                     AA
+                                        AA                   AAAAAAAAAAAAAA     AA
+                                        AA  AAAAAAAAAAAAAAAAAAAAAAAA    AAAAAAA AA
+                                       AAAAAAAAAAA                           AA AA
+                                                                           AAA  AA
+                                                                         AAAA   AA
+                                                                      AAAA      AA
+                                                                   AAAAA        AA
+                                                               AAAAA            AA
+                                                            AAAAA               AA
+                                                        AAAAAA                  AA
+                                                    AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+
+
+######################################################################################################################
+
+                                                Copyright (c) JoeShade
+                              Licensed under the GNU Affero General Public License v3.0
+
+######################################################################################################################
+
+                                        +44 (0) 7356 042702 | joe@jshade.co.uk
+
+######################################################################################################################
+*/

--- a/src/popup.css
+++ b/src/popup.css
@@ -209,13 +209,3 @@ h1 {
 .footer-link:focus {
   text-decoration: underline;
 }
-/*
- * This file is part of easyEdaDownloader.
- *
- * easyEdaDownloader is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This software is derived from easyeda2kicad.py by uPesy.
- */

--- a/src/popup.html
+++ b/src/popup.html
@@ -75,13 +75,3 @@
     <script src="popup.js"></script>
   </body>
 </html>
-<!--
-  This file is part of easyEdaDownloader.
-
-  easyEdaDownloader is free software: you can redistribute it and/or modify
-  it under the terms of the GNU Affero General Public License as published by
-  the Free Software Foundation, either version 3 of the License, or
-  (at your option) any later version.
-
-  This software is derived from easyeda2kicad.py by uPesy.
--->

--- a/src/popup.js
+++ b/src/popup.js
@@ -1,15 +1,4 @@
 /*
- * This file is part of easyEdaDownloader.
- *
- * easyEdaDownloader is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This software is derived from easyeda2kicad.py by uPesy.
- */
-
-/*
  * This script powers the extension popup UI. It fetches the LCSC
  * part number from the active tab, lets the user choose what to download, and
  * sends a request to the background service worker to start the export.
@@ -282,3 +271,46 @@ downloadButton.addEventListener("click", () => {
     }
   );
 });
+
+/*
+######################################################################################################################
+
+
+                                        AAAAAAAA
+                                      AAAA    AAAAA              AAAAAAAA
+                                    AAA          AAA           AAAA    AAA
+                                    AA            AA          AAA       AAA
+                                    AA            AAAAAAAAAA  AAA       AAAAAAAAAA
+                                    AAA                  AAA  AAA               AA
+                                     AAA                AAA    AAAAA            AA
+                                      AAAAA            AAA        AAA           AA
+                                         AAA          AAA                       AA
+                                         AAA         AAA                        AA
+                                         AA         AAA                         AA
+                                         AA        AAA                          AA
+                                        AAA       AAAAAAAAA                     AA
+                                        AAA       AAAAAAAAA                     AA
+                                        AA                   AAAAAAAAAAAAAA     AA
+                                        AA  AAAAAAAAAAAAAAAAAAAAAAAA    AAAAAAA AA
+                                       AAAAAAAAAAA                           AA AA
+                                                                           AAA  AA
+                                                                         AAAA   AA
+                                                                      AAAA      AA
+                                                                   AAAAA        AA
+                                                               AAAAA            AA
+                                                            AAAAA               AA
+                                                        AAAAAA                  AA
+                                                    AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+
+
+######################################################################################################################
+
+                                                Copyright (c) JoeShade
+                              Licensed under the GNU Affero General Public License v3.0
+
+######################################################################################################################
+
+                                        +44 (0) 7356 042702 | joe@jshade.co.uk
+
+######################################################################################################################
+*/

--- a/src/service_worker.js
+++ b/src/service_worker.js
@@ -691,12 +691,44 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
   return false;
 });
 /*
- * This file is part of easyEdaDownloader.
- *
- * easyEdaDownloader is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This software is derived from easyeda2kicad.py by uPesy.
- */
+######################################################################################################################
+
+
+                                        AAAAAAAA
+                                      AAAA    AAAAA              AAAAAAAA
+                                    AAA          AAA           AAAA    AAA
+                                    AA            AA          AAA       AAA
+                                    AA            AAAAAAAAAA  AAA       AAAAAAAAAA
+                                    AAA                  AAA  AAA               AA
+                                     AAA                AAA    AAAAA            AA
+                                      AAAAA            AAA        AAA           AA
+                                         AAA          AAA                       AA
+                                         AAA         AAA                        AA
+                                         AA         AAA                         AA
+                                         AA        AAA                          AA
+                                        AAA       AAAAAAAAA                     AA
+                                        AAA       AAAAAAAAA                     AA
+                                        AA                   AAAAAAAAAAAAAA     AA
+                                        AA  AAAAAAAAAAAAAAAAAAAAAAAA    AAAAAAA AA
+                                       AAAAAAAAAAA                           AA AA
+                                                                           AAA  AA
+                                                                         AAAA   AA
+                                                                      AAAA      AA
+                                                                   AAAAA        AA
+                                                               AAAAA            AA
+                                                            AAAAA               AA
+                                                        AAAAAA                  AA
+                                                    AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+
+
+######################################################################################################################
+
+                                                Copyright (c) JoeShade
+                              Licensed under the GNU Affero General Public License v3.0
+
+######################################################################################################################
+
+                                        +44 (0) 7356 042702 | joe@jshade.co.uk
+
+######################################################################################################################
+*/

--- a/systemDesign.md
+++ b/systemDesign.md
@@ -1,0 +1,221 @@
+# System Design: EasyEDA Downloader
+
+## 1. Purpose
+
+This document describes the current implemented design of the EasyEDA Downloader browser extension.
+
+The extension is intentionally narrow:
+
+- detect an LCSC part id from supported product pages
+- fetch EasyEDA-backed CAD data for that part
+- generate KiCad-compatible symbol, footprint, and 3D outputs
+- optionally download a datasheet when the upstream payload exposes one
+- save outputs either as loose files or under a KiCad-style library directory
+
+This document should describe what the repository actually does today. If code and design diverge, update one of them in the same change.
+
+## 2. Scope and non-goals
+
+### 2.1 Implemented workflow
+
+The current extension supports this operator flow:
+
+1. Open a supported JLCPCB or LCSC product page.
+2. Open the extension popup.
+3. Ask the content script to detect the LCSC part id from the current page.
+4. Ask the service worker for symbol and footprint previews plus datasheet availability metadata.
+5. Choose which artifacts to export and whether to download them individually.
+6. Ask the service worker to fetch EasyEDA CAD data, convert it, and trigger downloads.
+
+### 2.2 Explicit non-goals
+
+The current repository does not implement:
+
+- browser automation outside the popup/content-script/service-worker model
+- a fake multi-layer application architecture beyond the existing file split
+- end-to-end browser-run integration tests inside real Chrome or Firefox
+- production refactors for testability
+- custom network backends beyond the currently hard-coded EasyEDA and module endpoints
+
+## 3. Supported contexts and assumptions
+
+- The content script is injected only on matching JLCPCB and LCSC pages.
+- The extension assumes the page exposes an LCSC-style part id such as `C12345` somewhere in a definition list, product table, or the broader page text.
+- The popup assumes it is opened against an active tab and that the content script can answer `GET_LCSC_ID` on supported pages.
+- EasyEDA API responses are treated as the authoritative CAD payload source.
+- 3D model downloads depend on footprint metadata exposing a model UUID.
+- Datasheet download availability depends on URLs present in the EasyEDA payload.
+
+## 4. Repository architecture
+
+The runtime is intentionally direct and file-oriented.
+
+### 4.1 `src/content_script.js`
+
+Owns page inspection only:
+
+- label normalization
+- LCSC id extraction from text
+- definition-list scanning
+- table scanning
+- full-page text fallback
+- reply to popup-originated `GET_LCSC_ID` requests
+
+It should remain a small DOM-reading boundary with no network or download logic.
+
+### 4.2 `src/popup.js`
+
+Owns popup UI state and user interaction:
+
+- cache popup DOM elements
+- load and save popup settings through `chrome.storage.local`
+- query the active tab and request the current LCSC id
+- request previews and datasheet availability
+- keep the Download button enabled only when a part id and at least one selected artifact exist
+- display normal, warning, and error status text
+- send `EXPORT_PART` requests to the service worker
+
+It should remain the UI-facing boundary. It should not own EasyEDA fetches, conversion logic, or download orchestration.
+
+### 4.3 `src/service_worker.js`
+
+Owns orchestration and browser-integrated work:
+
+- settings load for download behavior
+- EasyEDA CAD payload fetches
+- preview SVG generation from CAD payload data
+- datasheet URL normalization and filename derivation
+- symbol-library merge behavior backed by `chrome.storage.local`
+- STEP and OBJ fetches for 3D model export
+- OBJ-to-WRL conversion via the converter module
+- download triggering through `chrome.downloads`
+- warning accumulation and response shaping for popup requests
+
+This file is the operational core of the extension.
+
+### 4.4 `src/kicad_converter.js`
+
+Owns conversion rules that are largely testable without browser APIs:
+
+- EasyEDA symbol parsing
+- EasyEDA footprint parsing
+- coordinate, unit, and text-style conversion
+- KiCad symbol text generation
+- KiCad footprint text generation
+- OBJ/MTL-style parsing and WRL emission
+
+It should remain the main pure conversion boundary.
+
+### 4.5 `tests`
+
+The test suite is the primary regression net for:
+
+- pure conversion behavior
+- page-detection logic
+- popup state transitions and messaging
+- service-worker orchestration and download behavior
+- repository governance and footer discipline
+
+## 5. Core data flow
+
+### 5.1 Detect LCSC id
+
+- The popup queries the active tab.
+- The popup asks the content script for `GET_LCSC_ID`.
+- The content script checks definition lists first, then the known table layout, then falls back to a page-wide scan.
+- The popup stores the detected id and updates UI state.
+
+### 5.2 Request previews
+
+- Once a part id is available, the popup asks the service worker for `GET_PREVIEW_SVGS`.
+- The service worker fetches the EasyEDA CAD payload.
+- The service worker derives lightweight SVG previews from the symbol and footprint portions of the payload.
+- The popup renders those previews and updates datasheet availability state.
+
+### 5.3 Fetch EasyEDA CAD payload
+
+- The service worker fetches the EasyEDA component payload using the detected LCSC id.
+- Missing or invalid payloads are treated as errors.
+- The fetched payload is reused for preview generation, datasheet inspection, and export orchestration.
+
+### 5.4 Generate KiCad outputs
+
+- The service worker asks `src/kicad_converter.js` to convert symbol and footprint data when those exports are requested.
+- The converter parses EasyEDA payload strings, normalizes geometry/text, and emits KiCad-compatible text files.
+- When a footprint exposes 3D model metadata, the service worker fetches STEP and OBJ assets and converts OBJ to WRL.
+
+### 5.5 Handle datasheet URL
+
+- The service worker derives datasheet availability from payload URLs in package, symbol, or LCSC metadata.
+- URL normalization handles protocol-relative URLs.
+- Datasheet filenames are derived from package/title metadata and preserve the upstream file extension when one can be determined.
+- Missing datasheets do not fail the whole export; they surface as warnings.
+
+### 5.6 Download behavior
+
+- If `downloadIndividually` is `true`, artifacts are downloaded as loose files.
+- Otherwise, downloads use a KiCad-style directory structure rooted at `easyEDADownloader/`.
+- Symbol downloads in library mode merge into `easyEDADownloader/easyEDADownloader.kicad_sym`.
+- Footprints download into `easyEDADownloader/easyEDADownloader.pretty/`.
+- 3D assets download into `easyEDADownloader/easyEDADownloader.3dshapes/`.
+- Datasheets download either as loose files or under `easyEDADownloader/`.
+
+## 6. Storage and settings behavior
+
+- `chrome.storage.local` stores popup settings, currently `downloadIndividually`.
+- `chrome.storage.local` also stores the accumulated symbol library content used for append-style symbol exports in library mode.
+- Popup settings are convenience state for UI behavior.
+- Stored symbol library content is operational state used to preserve prior symbol exports across popup sessions.
+
+## 7. Preview generation behavior
+
+- Preview generation happens in the service worker, not in the popup.
+- Symbol previews are synthesized from EasyEDA symbol primitives.
+- Footprint previews are synthesized from footprint pads and selected graphics primitives.
+- Preview generation is best-effort. Missing previewable data produces unavailable-state UI rather than blocking the popup entirely.
+
+## 8. Error and warning handling
+
+- Detection failures in the popup produce user-facing status messages and disable export.
+- Service-worker preview failures return structured error responses to the popup.
+- Export failures return structured error responses to the popup.
+- Partial export issues that do not invalidate the whole request, such as missing datasheets, are accumulated as warnings.
+- The popup distinguishes default, warning, and error status tones.
+
+## 9. External dependencies and browser APIs
+
+### 9.1 Network dependencies
+
+- EasyEDA component API for CAD payloads
+- EasyEDA module endpoints for STEP and OBJ assets
+
+### 9.2 Browser APIs
+
+- `chrome.tabs`
+- `chrome.runtime`
+- `chrome.storage.local`
+- `chrome.downloads`
+- `Blob` and `URL.createObjectURL` when available for download-safe object URLs
+
+## 10. Output artifacts and naming rules
+
+- Symbol output uses KiCad symbol library text and either a standalone `<lcscId>-<symbolName>.kicad_sym` file or the shared library file.
+- Footprint output uses `<footprintName>.kicad_mod`.
+- 3D outputs use sanitized model names for downloaded STEP and WRL files.
+- Datasheet output uses a sanitized base name plus `-datasheet` and the detected file extension.
+- The library root name is currently fixed as `easyEDADownloader`.
+
+## 11. Maintainability and testing boundaries
+
+- `src/kicad_converter.js` should stay the main unit-test target for pure conversion rules.
+- `src/content_script.js` should stay small enough to test through DOM fixtures and message mocks.
+- `src/popup.js` should be tested with DOM fixtures and mocked browser APIs rather than real extension runs.
+- `src/service_worker.js` should be tested with mocked browser APIs, mocked fetch, and controlled converter stubs.
+- Production source should not be refactored solely to make tests easier; harnesses should adapt to the existing code shape.
+
+## 12. Repository rules that should remain true
+
+- Do not change extension runtime behavior casually.
+- Do not reorganize production files without a real architectural reason.
+- Keep browser API orchestration in the service worker, UI state in the popup, DOM extraction in the content script, and conversion rules in the converter.
+- Keep governance files and hygiene tests aligned with the codebase.

--- a/tests/helpers/fixtures.js
+++ b/tests/helpers/fixtures.js
@@ -1,77 +1,82 @@
-/*
- * This content script runs in JLCPCB/LCSC pages and tries to
- * locate the LCSC part number by scanning common page layouts. It looks in
- * definition lists and table rows first, then falls back to a full-page scan.
- */
-
-// Normalize a label so we can compare it reliably.
-function normalizeLabel(text) {
-  return text.replace(/\s+/g, " ").trim().toLowerCase();
-}
-
-// Pull the LCSC part id (e.g., C12345) out of a text string.
-function extractLcscId(text) {
-  if (!text) {
-    return null;
-  }
-  const match = text.toUpperCase().match(/C\d{3,}/);
-  return match ? match[0] : null;
-}
-
-// Search definition list entries (<dl><dt><dd>) for the part number.
-function findInDefinitionLists() {
-  const lists = document.querySelectorAll("dl");
-  for (const list of lists) {
-    const dt = list.querySelector("dt");
-    const dd = list.querySelector("dd");
-    if (!dt || !dd) {
-      continue;
-    }
-    const label = normalizeLabel(dt.textContent || "");
-    if (label.includes("jlcpcb part #") || label.includes("lcsc part #")) {
-      const lcscId = extractLcscId(dd.textContent);
-      if (lcscId) {
-        return lcscId;
+export function createCadData({
+  lcscId = "C12345",
+  datasheetUrl = "https://cdn.example.test/datasheets/demo-part.pdf",
+  modelUuid = "model-uuid-1",
+  modelName = "Model QFN"
+} = {}) {
+  return {
+    SMT: true,
+    title: "Demo Logic Part",
+    lcsc: {
+      number: lcscId,
+      url: datasheetUrl
+    },
+    dataStr: {
+      BBox: { x: 10, y: 20, width: 80, height: 50 },
+      head: {
+        x: 10,
+        y: 20,
+        c_para: {
+          name: "Logic / Buffer",
+          pre: "U?",
+          package: "QFN-16/Example",
+          BOM_Manufacturer: "ACME Semi",
+          "BOM_JLCPCB Part Class": "JLC-001",
+          link: datasheetUrl
+        }
+      },
+      shape: [
+        "P~show~1~1~20~30~0~pin-1~false^^0^^M 20 30 h10~#000^^show~24~30~0~CLK#/RESET#~start~Arial~7pt^^0^^show~19~30^^show~M 0 0",
+        "R~30~25~0~0~40~20",
+        "PL~30 25 70 25 70 45~#000~0~0~none",
+        "PG~30 25 50 15 70 25",
+        "C~50~35~5~#000~0~none",
+        "A~M 30 35 A 5 5 0 0 1 40 45~#000~0~0~none",
+        "PT~M 30 25 L 40 35 L 30 45 Z"
+      ]
+    },
+    packageDetail: {
+      title: "QFN-16/Example",
+      dataStr: {
+        BBox: { x: 90, y: 190, width: 40, height: 30 },
+        head: {
+          x: 100,
+          y: 200,
+          c_para: {
+            package: "QFN-16/Example",
+            link: datasheetUrl,
+            "3DModel": modelName
+          }
+        },
+        shape: [
+          "PAD~RECT~100~200~20~10~1~~(1)~0~~90~pad-1~0~~true~false",
+          "PAD~POLYGON~120~200~10~10~1~~2~0~120 195 125 205 115 205~0~pad-2~0~~true~false",
+          "TRACK~1~3~~100 190 120 190 120 210~track-1~false",
+          "HOLE~110~210~2~hole-1~false",
+          "VIA~118~208~3~~1~via-1~false",
+          "CIRCLE~110~210~5~1~3~circle-1~false",
+          "ARC~1~3~~M 100 200 A 10 10 0 0 1 120 200~~arc-1~false",
+          "RECT~95~195~30~20~1~rect-1~3~false",
+          "TEXT~N~105~205~0.5~270~~3~~4~REF**~~show~text-1~false",
+          `SVGNODE~{"attrs":{"title":"${modelName}","uuid":"${modelUuid}","c_origin":"105,205","c_rotation":"0,90,180","z":"2"}}`
+        ]
       }
     }
-  }
-  return null;
+  };
 }
 
-// Search the common product table layout for the part number.
-function findInTables() {
-  const rows = document.querySelectorAll("table.tableInfoWrap tr");
-  for (const row of rows) {
-    const cells = row.querySelectorAll("td");
-    if (cells.length < 2) {
-      continue;
-    }
-    const label = normalizeLabel(cells[0].textContent || "");
-    if (label.includes("lcsc part #")) {
-      const lcscId = extractLcscId(cells[1].textContent);
-      if (lcscId) {
-        return lcscId;
-      }
-    }
-  }
-  return null;
+export function createSymbolLibrary(symbolId = "ExistingSymbol") {
+  return `(kicad_symbol_lib
+  (version 20211014)
+  (generator "easy EDA downloader")
+  (symbol "${symbolId}"
+    (in_bom yes)
+    (on_board yes)
+  )
+)
+`;
 }
 
-// Try the targeted searches first, then scan the entire page as a fallback.
-function findLcscId() {
-  return findInDefinitionLists() || findInTables() || extractLcscId(document.body.textContent);
-}
-
-// Listen for extension messages and reply with the detected LCSC id.
-chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
-  if (message?.type !== "GET_LCSC_ID") {
-    return false;
-  }
-
-  const lcscId = findLcscId();
-  sendResponse({ lcscId });
-  return true;
-});
 /*
 ######################################################################################################################
 

--- a/tests/helpers/test_harness.js
+++ b/tests/helpers/test_harness.js
@@ -1,77 +1,73 @@
-/*
- * This content script runs in JLCPCB/LCSC pages and tries to
- * locate the LCSC part number by scanning common page layouts. It looks in
- * definition lists and table rows first, then falls back to a full-page scan.
- */
+import fs from "node:fs";
+import path from "node:path";
+import vm from "node:vm";
 
-// Normalize a label so we can compare it reliably.
-function normalizeLabel(text) {
-  return text.replace(/\s+/g, " ").trim().toLowerCase();
+const FALLBACK_ATOB = (value) => Buffer.from(value, "base64").toString("binary");
+const FALLBACK_BTOA = (value) => Buffer.from(value, "binary").toString("base64");
+
+export const REPO_ROOT = path.resolve(import.meta.dirname, "..", "..");
+
+export function readRepoFile(relativePath) {
+  return fs.readFileSync(path.join(REPO_ROOT, relativePath), "utf8");
 }
 
-// Pull the LCSC part id (e.g., C12345) out of a text string.
-function extractLcscId(text) {
-  if (!text) {
-    return null;
+export function runSourceFile(
+  relativePath,
+  { context = {}, transforms = [], append = "" } = {}
+) {
+  let source = readRepoFile(relativePath);
+  for (const transform of transforms) {
+    source = transform(source);
   }
-  const match = text.toUpperCase().match(/C\d{3,}/);
-  return match ? match[0] : null;
-}
-
-// Search definition list entries (<dl><dt><dd>) for the part number.
-function findInDefinitionLists() {
-  const lists = document.querySelectorAll("dl");
-  for (const list of lists) {
-    const dt = list.querySelector("dt");
-    const dd = list.querySelector("dd");
-    if (!dt || !dd) {
-      continue;
-    }
-    const label = normalizeLabel(dt.textContent || "");
-    if (label.includes("jlcpcb part #") || label.includes("lcsc part #")) {
-      const lcscId = extractLcscId(dd.textContent);
-      if (lcscId) {
-        return lcscId;
-      }
-    }
-  }
-  return null;
-}
-
-// Search the common product table layout for the part number.
-function findInTables() {
-  const rows = document.querySelectorAll("table.tableInfoWrap tr");
-  for (const row of rows) {
-    const cells = row.querySelectorAll("td");
-    if (cells.length < 2) {
-      continue;
-    }
-    const label = normalizeLabel(cells[0].textContent || "");
-    if (label.includes("lcsc part #")) {
-      const lcscId = extractLcscId(cells[1].textContent);
-      if (lcscId) {
-        return lcscId;
-      }
-    }
-  }
-  return null;
-}
-
-// Try the targeted searches first, then scan the entire page as a fallback.
-function findLcscId() {
-  return findInDefinitionLists() || findInTables() || extractLcscId(document.body.textContent);
-}
-
-// Listen for extension messages and reply with the detected LCSC id.
-chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
-  if (message?.type !== "GET_LCSC_ID") {
-    return false;
+  if (append) {
+    source = `${source}\n${append}\n`;
   }
 
-  const lcscId = findLcscId();
-  sendResponse({ lcscId });
-  return true;
-});
+  const script = new vm.Script(source, { filename: relativePath });
+  const vmContext = vm.createContext({
+    console,
+    setTimeout,
+    clearTimeout,
+    setInterval,
+    clearInterval,
+    Promise,
+    Map,
+    WeakMap,
+    ArrayBuffer,
+    Uint8Array,
+    URL,
+    Blob,
+    TextEncoder,
+    TextDecoder,
+    atob: globalThis.atob || FALLBACK_ATOB,
+    btoa: globalThis.btoa || FALLBACK_BTOA,
+    encodeURIComponent,
+    decodeURIComponent,
+    unescape: globalThis.unescape,
+    ...context
+  });
+
+  script.runInContext(vmContext);
+  return vmContext;
+}
+
+export function replaceExactImport(source, fromText, toText) {
+  return source.replace(fromText, toText);
+}
+
+export function stripEsmFunctionExports(source) {
+  return source.replace(/^export function /gm, "function ");
+}
+
+export function normalizeNewlines(text) {
+  return String(text).replace(/\r\n/g, "\n");
+}
+
+export async function flushAsyncWork() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
 /*
 ######################################################################################################################
 

--- a/tests/test_content_script.test.js
+++ b/tests/test_content_script.test.js
@@ -1,77 +1,88 @@
-/*
- * This content script runs in JLCPCB/LCSC pages and tries to
- * locate the LCSC part number by scanning common page layouts. It looks in
- * definition lists and table rows first, then falls back to a full-page scan.
- */
+import { describe, expect, it, vi } from "vitest";
+import { JSDOM } from "jsdom";
 
-// Normalize a label so we can compare it reliably.
-function normalizeLabel(text) {
-  return text.replace(/\s+/g, " ").trim().toLowerCase();
-}
+import { runSourceFile } from "./helpers/test_harness.js";
 
-// Pull the LCSC part id (e.g., C12345) out of a text string.
-function extractLcscId(text) {
-  if (!text) {
-    return null;
-  }
-  const match = text.toUpperCase().match(/C\d{3,}/);
-  return match ? match[0] : null;
-}
-
-// Search definition list entries (<dl><dt><dd>) for the part number.
-function findInDefinitionLists() {
-  const lists = document.querySelectorAll("dl");
-  for (const list of lists) {
-    const dt = list.querySelector("dt");
-    const dd = list.querySelector("dd");
-    if (!dt || !dd) {
-      continue;
-    }
-    const label = normalizeLabel(dt.textContent || "");
-    if (label.includes("jlcpcb part #") || label.includes("lcsc part #")) {
-      const lcscId = extractLcscId(dd.textContent);
-      if (lcscId) {
-        return lcscId;
+function loadContentScript(markup) {
+  const dom = new JSDOM(`<!doctype html><html><body>${markup}</body></html>`, {
+    url: "https://example.test/"
+  });
+  const listeners = [];
+  const chrome = {
+    runtime: {
+      onMessage: {
+        addListener(listener) {
+          listeners.push(listener);
+        }
       }
     }
-  }
-  return null;
+  };
+
+  const context = runSourceFile("src/content_script.js", {
+    context: {
+      chrome,
+      document: dom.window.document,
+      window: dom.window
+    },
+    append: `
+globalThis.__testExports = {
+  normalizeLabel,
+  extractLcscId,
+  findInDefinitionLists,
+  findInTables,
+  findLcscId
+};
+`
+  });
+
+  return {
+    hooks: context.__testExports,
+    listener: listeners[0]
+  };
 }
 
-// Search the common product table layout for the part number.
-function findInTables() {
-  const rows = document.querySelectorAll("table.tableInfoWrap tr");
-  for (const row of rows) {
-    const cells = row.querySelectorAll("td");
-    if (cells.length < 2) {
-      continue;
-    }
-    const label = normalizeLabel(cells[0].textContent || "");
-    if (label.includes("lcsc part #")) {
-      const lcscId = extractLcscId(cells[1].textContent);
-      if (lcscId) {
-        return lcscId;
-      }
-    }
-  }
-  return null;
-}
+describe("content script", () => {
+  it("normalizes labels and extracts LCSC ids from text", () => {
+    const { hooks } = loadContentScript("<div>ignored</div>");
 
-// Try the targeted searches first, then scan the entire page as a fallback.
-function findLcscId() {
-  return findInDefinitionLists() || findInTables() || extractLcscId(document.body.textContent);
-}
+    expect(hooks.normalizeLabel("  LCSC   Part #  ")).toBe("lcsc part #");
+    expect(hooks.extractLcscId("Match c123456 here")).toBe("C123456");
+    expect(hooks.extractLcscId("No part id")).toBeNull();
+  });
 
-// Listen for extension messages and reply with the detected LCSC id.
-chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
-  if (message?.type !== "GET_LCSC_ID") {
-    return false;
-  }
+  it("detects LCSC ids in definition lists and tables", () => {
+    const { hooks } = loadContentScript(`
+      <dl>
+        <dt>JLCPCB Part #</dt>
+        <dd>C2040</dd>
+      </dl>
+      <table class="tableInfoWrap">
+        <tr>
+          <td>LCSC Part #</td>
+          <td>C9988</td>
+        </tr>
+      </table>
+    `);
 
-  const lcscId = findLcscId();
-  sendResponse({ lcscId });
-  return true;
+    expect(hooks.findInDefinitionLists()).toBe("C2040");
+    expect(hooks.findInTables()).toBe("C9988");
+  });
+
+  it("falls back to a page-wide scan and answers extension messages", () => {
+    const { hooks, listener } = loadContentScript(`
+      <section>
+        Product details mention c777888 in plain text.
+      </section>
+    `);
+
+    expect(hooks.findLcscId()).toBe("C777888");
+
+    const sendResponse = vi.fn();
+    expect(listener({ type: "GET_LCSC_ID" }, null, sendResponse)).toBe(true);
+    expect(sendResponse).toHaveBeenCalledWith({ lcscId: "C777888" });
+  });
 });
+
 /*
 ######################################################################################################################
 

--- a/tests/test_kicad_converter.test.js
+++ b/tests/test_kicad_converter.test.js
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "vitest";
+
+import { createCadData } from "./helpers/fixtures.js";
+import {
+  runSourceFile,
+  stripEsmFunctionExports
+} from "./helpers/test_harness.js";
+
+function loadConverter() {
+  const context = runSourceFile("src/kicad_converter.js", {
+    transforms: [stripEsmFunctionExports],
+    append: `
+globalThis.__testExports = {
+  applyTextStyle,
+  applyPinNameStyle,
+  parseSvgPath,
+  drillToKi,
+  convertEasyedaCadToKicad,
+  convertObjToWrlString
+};
+`
+  });
+
+  return context.__testExports;
+}
+
+describe("kicad converter", () => {
+  it("applies EasyEDA text styling rules to suffix-marked labels", () => {
+    const hooks = loadConverter();
+
+    expect(hooks.applyTextStyle("RESET#")).toBe("~{RESET}");
+    expect(hooks.applyPinNameStyle("CLK#/RESET#")).toBe("~{CLK}/~{RESET}");
+  });
+
+  it("converts representative symbol data into a KiCad symbol library", () => {
+    const hooks = loadConverter();
+    const result = hooks.convertEasyedaCadToKicad(createCadData(), {
+      symbol: true
+    });
+
+    expect(result.symbol.name).toBe("Logic_Buffer");
+    expect(result.symbol.content).toContain('(symbol "Logic_Buffer"');
+    expect(result.symbol.content).toMatch(/"LCSC Part"\s+"C12345"/);
+    expect(result.symbol.content).toContain("(pin input inverted_clock");
+    expect(result.symbol.content).toContain('(name "~{CLK}/~{RESET}"');
+  });
+
+  it("converts representative footprint data into KiCad footprint text", () => {
+    const hooks = loadConverter();
+    const result = hooks.convertEasyedaCadToKicad(createCadData(), {
+      footprint: true
+    });
+
+    expect(result.footprint.name).toBe("QFN-16/Example");
+    expect(result.footprint.content).toContain("(module easyeda2kicad:QFN-16/Example");
+    expect(result.footprint.content).toContain("\t(attr smd)");
+    expect(result.footprint.content).toContain("(pad 1 smd rect");
+    expect(result.footprint.content).toContain("(primitives");
+    expect(result.footprint.content).toContain('(model "${KIPRJMOD}/Model QFN.wrl"');
+    expect(result.footprint.content).toContain("(layer F.Fab)");
+  });
+
+  it("keeps key geometry helpers stable for parsed paths and drill output", () => {
+    const hooks = loadConverter();
+    const parsed = hooks.parseSvgPath("M 0 0 A 5 5 0 0 1 10 10 L 20 20 Z");
+
+    expect(parsed.map((step) => step.type)).toEqual(["M", "A", "L", "Z"]);
+    expect(hooks.drillToKi(0.5, 1.5, 2, 1)).toBe("(drill oval 1.00 1.50)");
+    expect(hooks.drillToKi(0.5, 0, 2, 1)).toBe("(drill 1.00)");
+  });
+
+  it("converts OBJ material groups into WRL output", () => {
+    const hooks = loadConverter();
+    const objData = `
+newmtl body
+Ka 0.1 0.1 0.1
+Kd 0.4 0.5 0.6
+Ks 0.7 0.8 0.9
+d 1.0
+endmtl
+v 2.54 0 0
+v 0 2.54 0
+v 0 0 2.54
+usemtl body
+f 1 2 3
+`.trim();
+
+    const wrl = hooks.convertObjToWrlString(objData);
+
+    expect(wrl).toContain("#VRML V2.0 utf8");
+    expect(wrl).toContain("diffuseColor 0.4 0.5 0.6");
+    expect(wrl).toContain("1.0000 0.0000 0.0000");
+    expect(wrl).toContain("Shape{");
+  });
+});
+
+/*
+######################################################################################################################
+
+
+                                        AAAAAAAA
+                                      AAAA    AAAAA              AAAAAAAA
+                                    AAA          AAA           AAAA    AAA
+                                    AA            AA          AAA       AAA
+                                    AA            AAAAAAAAAA  AAA       AAAAAAAAAA
+                                    AAA                  AAA  AAA               AA
+                                     AAA                AAA    AAAAA            AA
+                                      AAAAA            AAA        AAA           AA
+                                         AAA          AAA                       AA
+                                         AAA         AAA                        AA
+                                         AA         AAA                         AA
+                                         AA        AAA                          AA
+                                        AAA       AAAAAAAAA                     AA
+                                        AAA       AAAAAAAAA                     AA
+                                        AA                   AAAAAAAAAAAAAA     AA
+                                        AA  AAAAAAAAAAAAAAAAAAAAAAAA    AAAAAAA AA
+                                       AAAAAAAAAAA                           AA AA
+                                                                           AAA  AA
+                                                                         AAAA   AA
+                                                                      AAAA      AA
+                                                                   AAAAA        AA
+                                                               AAAAA            AA
+                                                            AAAAA               AA
+                                                        AAAAAA                  AA
+                                                    AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+
+
+######################################################################################################################
+
+                                                Copyright (c) JoeShade
+                              Licensed under the GNU Affero General Public License v3.0
+
+######################################################################################################################
+
+                                        +44 (0) 7356 042702 | joe@jshade.co.uk
+
+######################################################################################################################
+*/

--- a/tests/test_popup.test.js
+++ b/tests/test_popup.test.js
@@ -1,0 +1,300 @@
+import { describe, expect, it, vi } from "vitest";
+import { JSDOM } from "jsdom";
+
+import {
+  flushAsyncWork,
+  readRepoFile,
+  runSourceFile
+} from "./helpers/test_harness.js";
+
+function createPopupChrome() {
+  const state = {
+    queryCalls: [],
+    tabMessages: [],
+    runtimeMessages: [],
+    storageGetCalls: [],
+    storageSetCalls: []
+  };
+
+  const chrome = {
+    runtime: {
+      lastError: null,
+      sendMessage: vi.fn((message, callback) => {
+        state.runtimeMessages.push({ message, callback });
+      })
+    },
+    tabs: {
+      query: vi.fn((queryInfo, callback) => {
+        state.queryCalls.push({ queryInfo, callback });
+      }),
+      sendMessage: vi.fn((tabId, message, callback) => {
+        state.tabMessages.push({ tabId, message, callback });
+      })
+    },
+    storage: {
+      local: {
+        get: vi.fn((defaults, callback) => {
+          state.storageGetCalls.push({ defaults, callback });
+        }),
+        set: vi.fn((items, callback) => {
+          state.storageSetCalls.push(items);
+          callback?.();
+        })
+      }
+    }
+  };
+
+  return { chrome, state };
+}
+
+function loadPopup() {
+  const dom = new JSDOM(readRepoFile("src/popup.html"), {
+    url: "https://example.test/popup.html"
+  });
+  const { chrome, state } = createPopupChrome();
+
+  const context = runSourceFile("src/popup.js", {
+    context: {
+      chrome,
+      document: dom.window.document,
+      window: dom.window,
+      Event: dom.window.Event
+    },
+    append: `
+globalThis.__testExports = {
+  setPartNumber,
+  updateDownloadEnabled,
+  setDatasheetAvailability,
+  hasSelection,
+  getCurrentLcscId: () => currentLcscId,
+  elements: {
+    partNumberEl,
+    downloadButton,
+    statusEl,
+    downloadSymbolEl,
+    downloadFootprintEl,
+    downloadModelEl,
+    downloadDatasheetEl,
+    downloadDatasheetOptionEl,
+    downloadDatasheetLabelEl,
+    downloadIndividuallyEl,
+    symbolPreviewEl,
+    footprintPreviewEl,
+    symbolPreviewFallbackEl,
+    footprintPreviewFallbackEl
+  }
+};
+`
+  });
+
+  return {
+    dom,
+    state,
+    hooks: context.__testExports
+  };
+}
+
+function dispatchChange(dom, element) {
+  element.dispatchEvent(new dom.window.Event("change", { bubbles: true }));
+}
+
+describe("popup", () => {
+  it("starts in a loading state and requests the active tab plus saved settings", () => {
+    const { state, hooks } = loadPopup();
+
+    expect(state.queryCalls).toHaveLength(1);
+    expect(state.queryCalls[0].queryInfo).toEqual({
+      active: true,
+      currentWindow: true
+    });
+    expect(state.storageGetCalls).toHaveLength(1);
+    expect(hooks.elements.partNumberEl.textContent).toBe("Searching...");
+    expect(hooks.elements.downloadButton.disabled).toBe(true);
+    expect(hooks.elements.symbolPreviewFallbackEl.textContent).toBe("Loading...");
+    expect(hooks.elements.footprintPreviewFallbackEl.textContent).toBe("Loading...");
+  });
+
+  it("loads settings and enables the download button only when a part and selection exist", async () => {
+    const { dom, state, hooks } = loadPopup();
+
+    state.storageGetCalls[0].callback({ downloadIndividually: true });
+    expect(hooks.elements.downloadIndividuallyEl.checked).toBe(true);
+
+    state.queryCalls[0].callback([{ id: 7 }]);
+    expect(state.tabMessages[0]).toMatchObject({
+      tabId: 7,
+      message: { type: "GET_LCSC_ID" }
+    });
+
+    state.tabMessages[0].callback({ lcscId: "C12345" });
+    expect(state.runtimeMessages[0].message).toEqual({
+      type: "GET_PREVIEW_SVGS",
+      lcscId: "C12345"
+    });
+
+    state.runtimeMessages[0].callback({
+      ok: true,
+      previews: {
+        symbolSvg: "<svg><rect /></svg>",
+        footprintSvg: "<svg><circle /></svg>"
+      },
+      metadata: {
+        datasheetAvailable: true
+      }
+    });
+    await flushAsyncWork();
+
+    expect(hooks.getCurrentLcscId()).toBe("C12345");
+    expect(hooks.elements.partNumberEl.textContent).toBe("C12345");
+    expect(hooks.elements.downloadButton.disabled).toBe(false);
+    expect(hooks.elements.symbolPreviewEl.src).toContain("data:image/svg+xml;utf8,");
+    expect(hooks.elements.footprintPreviewEl.src).toContain("data:image/svg+xml;utf8,");
+
+    hooks.elements.downloadSymbolEl.checked = false;
+    hooks.elements.downloadFootprintEl.checked = false;
+    hooks.elements.downloadModelEl.checked = false;
+    dispatchChange(dom, hooks.elements.downloadSymbolEl);
+    dispatchChange(dom, hooks.elements.downloadFootprintEl);
+    dispatchChange(dom, hooks.elements.downloadModelEl);
+    expect(hooks.elements.downloadButton.disabled).toBe(true);
+
+    hooks.elements.downloadSymbolEl.checked = true;
+    dispatchChange(dom, hooks.elements.downloadSymbolEl);
+    expect(hooks.elements.downloadButton.disabled).toBe(false);
+  });
+
+  it("saves settings when the download organization toggle changes", () => {
+    const { dom, state, hooks } = loadPopup();
+
+    state.storageGetCalls[0].callback({ downloadIndividually: false });
+    hooks.elements.downloadIndividuallyEl.checked = true;
+    dispatchChange(dom, hooks.elements.downloadIndividuallyEl);
+
+    expect(state.storageSetCalls).toEqual([{ downloadIndividually: true }]);
+  });
+
+  it("updates datasheet availability and reports export warnings", async () => {
+    const { state, hooks } = loadPopup();
+
+    state.storageGetCalls[0].callback({ downloadIndividually: false });
+    state.queryCalls[0].callback([{ id: 8 }]);
+    state.tabMessages[0].callback({ lcscId: "C55555" });
+
+    state.runtimeMessages[0].callback({
+      ok: true,
+      previews: {
+        symbolSvg: "<svg><rect /></svg>",
+        footprintSvg: "<svg><circle /></svg>"
+      },
+      metadata: {
+        datasheetAvailable: false
+      }
+    });
+    await flushAsyncWork();
+
+    expect(hooks.elements.downloadDatasheetEl.disabled).toBe(true);
+    expect(hooks.elements.downloadDatasheetLabelEl.textContent).toBe(
+      "Datasheet (not available)"
+    );
+
+    hooks.elements.downloadSymbolEl.checked = true;
+    hooks.elements.downloadFootprintEl.checked = false;
+    hooks.elements.downloadModelEl.checked = false;
+    hooks.elements.downloadButton.click();
+
+    expect(state.runtimeMessages[1].message).toEqual({
+      type: "EXPORT_PART",
+      lcscId: "C55555",
+      options: {
+        symbol: true,
+        footprint: false,
+        model3d: false,
+        datasheet: false,
+        downloadIndividually: false
+      }
+    });
+
+    state.runtimeMessages[1].callback({
+      ok: true,
+      downloadCount: 1,
+      warnings: ["Datasheet not available for this part."]
+    });
+    await flushAsyncWork();
+
+    expect(hooks.elements.statusEl.textContent).toContain("Datasheet not available");
+    expect(hooks.elements.statusEl.classList.contains("warning")).toBe(true);
+    expect(hooks.elements.downloadButton.disabled).toBe(false);
+  });
+
+  it("surfaces export errors in the popup status area", async () => {
+    const { state, hooks } = loadPopup();
+
+    state.storageGetCalls[0].callback({ downloadIndividually: false });
+    state.queryCalls[0].callback([{ id: 9 }]);
+    state.tabMessages[0].callback({ lcscId: "C90000" });
+    state.runtimeMessages[0].callback({
+      ok: true,
+      previews: {
+        symbolSvg: "<svg />",
+        footprintSvg: "<svg />"
+      },
+      metadata: {
+        datasheetAvailable: true
+      }
+    });
+    await flushAsyncWork();
+
+    hooks.elements.downloadButton.click();
+    state.runtimeMessages[1].callback({
+      ok: false,
+      error: "Download failed."
+    });
+    await flushAsyncWork();
+
+    expect(hooks.elements.statusEl.textContent).toBe("Download failed.");
+    expect(hooks.elements.statusEl.classList.contains("error")).toBe(true);
+  });
+});
+
+/*
+######################################################################################################################
+
+
+                                        AAAAAAAA
+                                      AAAA    AAAAA              AAAAAAAA
+                                    AAA          AAA           AAAA    AAA
+                                    AA            AA          AAA       AAA
+                                    AA            AAAAAAAAAA  AAA       AAAAAAAAAA
+                                    AAA                  AAA  AAA               AA
+                                     AAA                AAA    AAAAA            AA
+                                      AAAAA            AAA        AAA           AA
+                                         AAA          AAA                       AA
+                                         AAA         AAA                        AA
+                                         AA         AAA                         AA
+                                         AA        AAA                          AA
+                                        AAA       AAAAAAAAA                     AA
+                                        AAA       AAAAAAAAA                     AA
+                                        AA                   AAAAAAAAAAAAAA     AA
+                                        AA  AAAAAAAAAAAAAAAAAAAAAAAA    AAAAAAA AA
+                                       AAAAAAAAAAA                           AA AA
+                                                                           AAA  AA
+                                                                         AAAA   AA
+                                                                      AAAA      AA
+                                                                   AAAAA        AA
+                                                               AAAAA            AA
+                                                            AAAAA               AA
+                                                        AAAAAA                  AA
+                                                    AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+
+
+######################################################################################################################
+
+                                                Copyright (c) JoeShade
+                              Licensed under the GNU Affero General Public License v3.0
+
+######################################################################################################################
+
+                                        +44 (0) 7356 042702 | joe@jshade.co.uk
+
+######################################################################################################################
+*/

--- a/tests/test_repo_hygiene.test.js
+++ b/tests/test_repo_hygiene.test.js
@@ -1,0 +1,174 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { REPO_ROOT, normalizeNewlines } from "./helpers/test_harness.js";
+
+const GOVERNANCE_FILES = [
+  "AGENTS.md",
+  "systemDesign.md",
+  "docs/architecture-notes.md",
+  "docs/deviations.md"
+];
+
+const CANONICAL_FOOTER = normalizeNewlines(
+  [
+    "/*",
+    "######################################################################################################################",
+    "",
+    "",
+    "                                        AAAAAAAA",
+    "                                      AAAA    AAAAA              AAAAAAAA",
+    "                                    AAA          AAA           AAAA    AAA",
+    "                                    AA            AA          AAA       AAA",
+    "                                    AA            AAAAAAAAAA  AAA       AAAAAAAAAA",
+    "                                    AAA                  AAA  AAA               AA",
+    "                                     AAA                AAA    AAAAA            AA",
+    "                                      AAAAA            AAA        AAA           AA",
+    "                                         AAA          AAA                       AA",
+    "                                         AAA         AAA                        AA",
+    "                                         AA         AAA                         AA",
+    "                                         AA        AAA                          AA",
+    "                                        AAA       AAAAAAAAA                     AA",
+    "                                        AAA       AAAAAAAAA                     AA",
+    "                                        AA                   AAAAAAAAAAAAAA     AA",
+    "                                        AA  AAAAAAAAAAAAAAAAAAAAAAAA    AAAAAAA AA",
+    "                                       AAAAAAAAAAA                           AA AA",
+    "                                                                           AAA  AA",
+    "                                                                         AAAA   AA",
+    "                                                                      AAAA      AA",
+    "                                                                   AAAAA        AA",
+    "                                                               AAAAA            AA",
+    "                                                            AAAAA               AA",
+    "                                                        AAAAAA                  AA",
+    "                                                    AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+    "",
+    "",
+    "######################################################################################################################",
+    "",
+    "                                                Copyright (c) JoeShade",
+    "                              Licensed under the GNU Affero General Public License v3.0",
+    "",
+    "######################################################################################################################",
+    "",
+    "                                        +44 (0) 7356 042702 | joe@jshade.co.uk",
+    "",
+    "######################################################################################################################",
+    "*/"
+  ].join("\n")
+);
+
+function applicableSourceFiles() {
+  const files = [];
+
+  for (const root of ["src", "tests"]) {
+    const basePath = path.join(REPO_ROOT, root);
+    if (!fs.existsSync(basePath)) {
+      continue;
+    }
+    for (const entry of fs.readdirSync(basePath, { recursive: true })) {
+      const fullPath = path.join(basePath, entry);
+      if (fs.statSync(fullPath).isFile() && fullPath.endsWith(".js")) {
+        files.push(fullPath);
+      }
+    }
+  }
+
+  const supportFiles = [path.join(REPO_ROOT, "vitest.config.js")];
+  for (const fullPath of supportFiles) {
+    if (fs.existsSync(fullPath)) {
+      files.push(fullPath);
+    }
+  }
+
+  return files.sort();
+}
+
+describe("repository hygiene", () => {
+  it("requires the governance files", () => {
+    for (const relativePath of GOVERNANCE_FILES) {
+      expect(fs.existsSync(path.join(REPO_ROOT, relativePath))).toBe(true);
+    }
+  });
+
+  it("keeps the canonical footer on applicable maintained JS files exactly once", () => {
+    const missingOrDuplicated = [];
+
+    for (const fullPath of applicableSourceFiles()) {
+      const text = normalizeNewlines(fs.readFileSync(fullPath, "utf8"));
+      const occurrences = text.split(CANONICAL_FOOTER).length - 1;
+      if (occurrences !== 1) {
+        missingOrDuplicated.push(path.relative(REPO_ROOT, fullPath));
+      }
+    }
+
+    expect(missingOrDuplicated).toEqual([]);
+  });
+
+  it("keeps deviations focused on live mismatches rather than backlog or history", () => {
+    const deviationsText = normalizeNewlines(
+      fs.readFileSync(path.join(REPO_ROOT, "docs/deviations.md"), "utf8")
+    );
+
+    expect(deviationsText).toContain(
+      "No material code/design mismatches are intentionally tracked at this time."
+    );
+    expect(deviationsText).not.toMatch(/^\s*[-*]\s+/m);
+    expect(deviationsText).not.toMatch(/^\s*\d+\.\s+/m);
+    expect(deviationsText.trim().split("\n").length).toBeLessThanOrEqual(6);
+  });
+
+  it("does not keep stale footer migration language in governance docs", () => {
+    const governanceText = GOVERNANCE_FILES.map((relativePath) =>
+      normalizeNewlines(fs.readFileSync(path.join(REPO_ROOT, relativePath), "utf8"))
+    ).join("\n");
+
+    expect(governanceText).not.toContain("removed `source-code-footer.txt`");
+    expect(governanceText).not.toContain("copy an existing source file");
+    expect(governanceText.toLowerCase()).not.toContain("footer migration");
+  });
+});
+
+/*
+######################################################################################################################
+
+
+                                        AAAAAAAA
+                                      AAAA    AAAAA              AAAAAAAA
+                                    AAA          AAA           AAAA    AAA
+                                    AA            AA          AAA       AAA
+                                    AA            AAAAAAAAAA  AAA       AAAAAAAAAA
+                                    AAA                  AAA  AAA               AA
+                                     AAA                AAA    AAAAA            AA
+                                      AAAAA            AAA        AAA           AA
+                                         AAA          AAA                       AA
+                                         AAA         AAA                        AA
+                                         AA         AAA                         AA
+                                         AA        AAA                          AA
+                                        AAA       AAAAAAAAA                     AA
+                                        AAA       AAAAAAAAA                     AA
+                                        AA                   AAAAAAAAAAAAAA     AA
+                                        AA  AAAAAAAAAAAAAAAAAAAAAAAA    AAAAAAA AA
+                                       AAAAAAAAAAA                           AA AA
+                                                                           AAA  AA
+                                                                         AAAA   AA
+                                                                      AAAA      AA
+                                                                   AAAAA        AA
+                                                               AAAAA            AA
+                                                            AAAAA               AA
+                                                        AAAAAA                  AA
+                                                    AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+
+
+######################################################################################################################
+
+                                                Copyright (c) JoeShade
+                              Licensed under the GNU Affero General Public License v3.0
+
+######################################################################################################################
+
+                                        +44 (0) 7356 042702 | joe@jshade.co.uk
+
+######################################################################################################################
+*/

--- a/tests/test_service_worker.test.js
+++ b/tests/test_service_worker.test.js
@@ -1,0 +1,351 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createCadData, createSymbolLibrary } from "./helpers/fixtures.js";
+import {
+  flushAsyncWork,
+  replaceExactImport,
+  runSourceFile
+} from "./helpers/test_harness.js";
+
+function createServiceWorkerChrome({ storageState = {} } = {}) {
+  const listeners = {
+    runtimeMessage: [],
+    downloadsChanged: []
+  };
+  const storage = { ...storageState };
+  let nextDownloadId = 1;
+
+  const chrome = {
+    runtime: {
+      lastError: null,
+      onMessage: {
+        addListener(listener) {
+          listeners.runtimeMessage.push(listener);
+        }
+      }
+    },
+    downloads: {
+      download: vi.fn((options, callback) => {
+        const downloadId = nextDownloadId++;
+        callback?.(downloadId);
+        return downloadId;
+      }),
+      onChanged: {
+        addListener(listener) {
+          listeners.downloadsChanged.push(listener);
+        }
+      }
+    },
+    storage: {
+      local: {
+        get: vi.fn((defaults, callback) => {
+          if (typeof defaults === "string") {
+            callback({ [defaults]: storage[defaults] ?? "" });
+            return;
+          }
+          const result = {};
+          for (const [key, fallback] of Object.entries(defaults)) {
+            result[key] = Object.prototype.hasOwnProperty.call(storage, key)
+              ? storage[key]
+              : fallback;
+          }
+          callback(result);
+        }),
+        set: vi.fn((items, callback) => {
+          Object.assign(storage, items);
+          callback?.();
+        })
+      }
+    },
+    tabs: {
+      sendMessage: vi.fn()
+    }
+  };
+
+  return { chrome, listeners, storage };
+}
+
+function loadServiceWorker({
+  chrome,
+  fetchImpl,
+  convertEasyedaCadToKicad = vi.fn(() => ({})),
+  convertObjToWrlString = vi.fn(() => "#VRML")
+}) {
+  class MockURL extends URL {}
+  MockURL.createObjectURL = vi.fn(() => "blob:download");
+  MockURL.revokeObjectURL = vi.fn();
+
+  const context = runSourceFile("src/service_worker.js", {
+    context: {
+      chrome,
+      fetch: fetchImpl,
+      URL: MockURL,
+      Blob,
+      __converter: {
+        convertEasyedaCadToKicad,
+        convertObjToWrlString
+      }
+    },
+    transforms: [
+      (source) =>
+        replaceExactImport(
+          source,
+          'import { convertEasyedaCadToKicad, convertObjToWrlString } from "./kicad_converter.js";',
+          "const { convertEasyedaCadToKicad, convertObjToWrlString } = globalThis.__converter;"
+        )
+    ],
+    append: `
+globalThis.__testExports = {
+  exportPart,
+  fetchCadData,
+  buildLibraryPaths,
+  getDatasheetInfo,
+  extractSymbolBlock,
+  mergeSymbolIntoLibrary
+};
+`
+  });
+
+  return {
+    hooks: context.__testExports,
+    urlApi: MockURL
+  };
+}
+
+function sendRuntimeMessage(listener, message) {
+  return new Promise((resolve) => {
+    const handled = listener(message, null, (response) => resolve({ handled, response }));
+    if (handled === false) {
+      resolve({ handled, response: undefined });
+    }
+  });
+}
+
+describe("service worker", () => {
+  it("returns preview SVGs and datasheet availability for a valid CAD payload", async () => {
+    const cadData = createCadData();
+    const { chrome, listeners } = createServiceWorkerChrome();
+    loadServiceWorker({
+      chrome,
+      fetchImpl: vi.fn(async () => ({
+        ok: true,
+        json: async () => ({ result: cadData })
+      }))
+    });
+
+    const result = await sendRuntimeMessage(listeners.runtimeMessage[0], {
+      type: "GET_PREVIEW_SVGS",
+      lcscId: "C12345"
+    });
+
+    expect(result.handled).toBe(true);
+    expect(result.response.ok).toBe(true);
+    expect(result.response.previews.symbolSvg).toContain("<svg");
+    expect(result.response.previews.footprintSvg).toContain("<svg");
+    expect(result.response.metadata.datasheetAvailable).toBe(true);
+  });
+
+  it("exports library-structured downloads, merges symbol storage, and cleans up blob URLs", async () => {
+    const cadData = createCadData();
+    const { chrome, listeners, storage } = createServiceWorkerChrome({
+      storageState: {
+        downloadIndividually: false,
+        "symbolLibrary:easyEDADownloader/easyEDADownloader.kicad_sym":
+          createSymbolLibrary()
+      }
+    });
+    const convertEasyedaCadToKicad = vi.fn(() => ({
+      symbol: {
+        name: "Logic_Buffer",
+        content: `(kicad_symbol_lib
+  (version 20211014)
+  (generator "easy EDA downloader")
+  (symbol "Logic_Buffer"
+    (in_bom yes)
+    (on_board yes)
+  )
+)
+`
+      },
+      footprint: {
+        name: "QFN-16_Example",
+        content: "(module easyeda2kicad:QFN-16_Example)"
+      }
+    }));
+    const convertObjToWrlString = vi.fn(() => "#VRML");
+    const fetchImpl = vi.fn(async (url) => {
+      if (String(url).includes("/api/products/")) {
+        return {
+          ok: true,
+          json: async () => ({ result: cadData })
+        };
+      }
+      if (String(url).includes("/qAxj6KHrDKw4blvCG8QJPs7Y/")) {
+        return {
+          ok: true,
+          arrayBuffer: async () => new TextEncoder().encode("step").buffer
+        };
+      }
+      if (String(url).includes("/3dmodel/")) {
+        return {
+          ok: true,
+          text: async () => "obj data"
+        };
+      }
+      throw new Error(`Unexpected URL: ${url}`);
+    });
+
+    const { urlApi } = loadServiceWorker({
+      chrome,
+      fetchImpl,
+      convertEasyedaCadToKicad,
+      convertObjToWrlString
+    });
+
+    const result = await sendRuntimeMessage(listeners.runtimeMessage[0], {
+      type: "EXPORT_PART",
+      lcscId: "C12345",
+      options: {
+        symbol: true,
+        footprint: true,
+        model3d: true,
+        datasheet: true
+      }
+    });
+    await flushAsyncWork();
+
+    expect(result.response).toEqual({
+      ok: true,
+      warnings: [],
+      downloadCount: 5
+    });
+    expect(convertEasyedaCadToKicad).toHaveBeenCalledWith(cadData, {
+      symbol: true,
+      footprint: true
+    });
+    expect(convertObjToWrlString).toHaveBeenCalledWith("obj data");
+    expect(storage["symbolLibrary:easyEDADownloader/easyEDADownloader.kicad_sym"]).toContain(
+      '(symbol "ExistingSymbol"'
+    );
+    expect(storage["symbolLibrary:easyEDADownloader/easyEDADownloader.kicad_sym"]).toContain(
+      '(symbol "Logic_Buffer"'
+    );
+
+    const filenames = chrome.downloads.download.mock.calls.map(
+      ([options]) => options.filename
+    );
+    expect(filenames).toContain("easyEDADownloader/easyEDADownloader.kicad_sym");
+    expect(filenames).toContain(
+      "easyEDADownloader/easyEDADownloader.pretty/QFN-16_Example.kicad_mod"
+    );
+    expect(filenames).toContain(
+      "easyEDADownloader/easyEDADownloader.3dshapes/Model_QFN.step"
+    );
+    expect(filenames).toContain(
+      "easyEDADownloader/easyEDADownloader.3dshapes/Model_QFN.wrl"
+    );
+    expect(filenames).toContain("easyEDADownloader/QFN-16_Example-datasheet.pdf");
+
+    listeners.downloadsChanged[0]({
+      id: 1,
+      state: { current: "complete" }
+    });
+    expect(urlApi.revokeObjectURL).toHaveBeenCalledWith("blob:download");
+  });
+
+  it("returns a warning when datasheet export is requested but no datasheet URL exists", async () => {
+    const cadData = createCadData({ datasheetUrl: "" });
+    const { chrome, listeners } = createServiceWorkerChrome({
+      storageState: {
+        downloadIndividually: true
+      }
+    });
+    loadServiceWorker({
+      chrome,
+      fetchImpl: vi.fn(async () => ({
+        ok: true,
+        json: async () => ({ result: cadData })
+      }))
+    });
+
+    const result = await sendRuntimeMessage(listeners.runtimeMessage[0], {
+      type: "EXPORT_PART",
+      lcscId: "C12345",
+      options: {
+        symbol: false,
+        footprint: false,
+        model3d: false,
+        datasheet: true
+      }
+    });
+
+    expect(result.response).toEqual({
+      ok: true,
+      warnings: ["Datasheet not available for this part."],
+      downloadCount: 0
+    });
+    expect(chrome.downloads.download).not.toHaveBeenCalled();
+  });
+
+  it("reports invalid EasyEDA payloads as structured preview failures", async () => {
+    const { chrome, listeners } = createServiceWorkerChrome();
+    loadServiceWorker({
+      chrome,
+      fetchImpl: vi.fn(async () => ({
+        ok: true,
+        json: async () => ({ status: "missing-result" })
+      }))
+    });
+
+    const result = await sendRuntimeMessage(listeners.runtimeMessage[0], {
+      type: "GET_PREVIEW_SVGS",
+      lcscId: "C12345"
+    });
+
+    expect(result.response.ok).toBe(false);
+    expect(result.response.error).toContain("EasyEDA API returned no component data");
+  });
+});
+
+/*
+######################################################################################################################
+
+
+                                        AAAAAAAA
+                                      AAAA    AAAAA              AAAAAAAA
+                                    AAA          AAA           AAAA    AAA
+                                    AA            AA          AAA       AAA
+                                    AA            AAAAAAAAAA  AAA       AAAAAAAAAA
+                                    AAA                  AAA  AAA               AA
+                                     AAA                AAA    AAAAA            AA
+                                      AAAAA            AAA        AAA           AA
+                                         AAA          AAA                       AA
+                                         AAA         AAA                        AA
+                                         AA         AAA                         AA
+                                         AA        AAA                          AA
+                                        AAA       AAAAAAAAA                     AA
+                                        AAA       AAAAAAAAA                     AA
+                                        AA                   AAAAAAAAAAAAAA     AA
+                                        AA  AAAAAAAAAAAAAAAAAAAAAAAA    AAAAAAA AA
+                                       AAAAAAAAAAA                           AA AA
+                                                                           AAA  AA
+                                                                         AAAA   AA
+                                                                      AAAA      AA
+                                                                   AAAAA        AA
+                                                               AAAAA            AA
+                                                            AAAAA               AA
+                                                        AAAAAA                  AA
+                                                    AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+
+
+######################################################################################################################
+
+                                                Copyright (c) JoeShade
+                              Licensed under the GNU Affero General Public License v3.0
+
+######################################################################################################################
+
+                                        +44 (0) 7356 042702 | joe@jshade.co.uk
+
+######################################################################################################################
+*/

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,77 +1,12 @@
-/*
- * This content script runs in JLCPCB/LCSC pages and tries to
- * locate the LCSC part number by scanning common page layouts. It looks in
- * definition lists and table rows first, then falls back to a full-page scan.
- */
+import { defineConfig } from "vitest/config";
 
-// Normalize a label so we can compare it reliably.
-function normalizeLabel(text) {
-  return text.replace(/\s+/g, " ").trim().toLowerCase();
-}
-
-// Pull the LCSC part id (e.g., C12345) out of a text string.
-function extractLcscId(text) {
-  if (!text) {
-    return null;
+export default defineConfig({
+  test: {
+    environment: "jsdom",
+    include: ["tests/**/*.test.js"]
   }
-  const match = text.toUpperCase().match(/C\d{3,}/);
-  return match ? match[0] : null;
-}
-
-// Search definition list entries (<dl><dt><dd>) for the part number.
-function findInDefinitionLists() {
-  const lists = document.querySelectorAll("dl");
-  for (const list of lists) {
-    const dt = list.querySelector("dt");
-    const dd = list.querySelector("dd");
-    if (!dt || !dd) {
-      continue;
-    }
-    const label = normalizeLabel(dt.textContent || "");
-    if (label.includes("jlcpcb part #") || label.includes("lcsc part #")) {
-      const lcscId = extractLcscId(dd.textContent);
-      if (lcscId) {
-        return lcscId;
-      }
-    }
-  }
-  return null;
-}
-
-// Search the common product table layout for the part number.
-function findInTables() {
-  const rows = document.querySelectorAll("table.tableInfoWrap tr");
-  for (const row of rows) {
-    const cells = row.querySelectorAll("td");
-    if (cells.length < 2) {
-      continue;
-    }
-    const label = normalizeLabel(cells[0].textContent || "");
-    if (label.includes("lcsc part #")) {
-      const lcscId = extractLcscId(cells[1].textContent);
-      if (lcscId) {
-        return lcscId;
-      }
-    }
-  }
-  return null;
-}
-
-// Try the targeted searches first, then scan the entire page as a fallback.
-function findLcscId() {
-  return findInDefinitionLists() || findInTables() || extractLcscId(document.body.textContent);
-}
-
-// Listen for extension messages and reply with the detected LCSC id.
-chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
-  if (message?.type !== "GET_LCSC_ID") {
-    return false;
-  }
-
-  const lcscId = findLcscId();
-  sendResponse({ lcscId });
-  return true;
 });
+
 /*
 ######################################################################################################################
 


### PR DESCRIPTION
## Summary
- add repo governance docs aligned to the current browser-extension architecture
- add Vitest-based unit, implementation, and repo-hygiene coverage
- apply the canonical source footer policy and contributor guidance

## Validation
- npm test